### PR TITLE
Bug fix, handle positional args for page event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lmn-gtm-analytics",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "GTM/Segment Integration for Lost My Name",
   "main": "dist/lmn-gtm-analytics.js",
   "scripts": {

--- a/test/unit/lmn-gtm-analytics.js
+++ b/test/unit/lmn-gtm-analytics.js
@@ -41,7 +41,8 @@ describe('lmnAnalytics', () => {
 
       expect(global.analytics.track).to.have.been.calledWithMatch('Custom Event', {
         category: 'test',
-        label: 'test'
+        label: 'test',
+        gaCookieId: 'not-set'
       });
     });
 
@@ -155,7 +156,24 @@ describe('lmnAnalytics', () => {
       });
 
       expect(global.analytics.page).to.have.been.calledWithMatch('Creation Canvas', {
-        locale: 'en-GB'
+        locale: 'en-GB',
+        gaCookieId: 'not-set'
+      });
+    });
+
+    it('should include event meta when name sent (regression)', () => {
+      lmnAnalytics.page('Creation Canvas 1', 'Canvas');
+
+      expect(global.analytics.page).to.have.been.calledWithMatch('Creation Canvas 1', 'Canvas', {
+        gaCookieId: 'not-set'
+      });
+    });
+
+    it('should include event meta when only category sent (regression)', () => {
+      lmnAnalytics.page('Creation Canvas Test 2');
+
+      expect(global.analytics.page).to.have.been.calledWithMatch('Creation Canvas Test 2', {
+        gaCookieId: 'not-set'
       });
     });
 
@@ -239,6 +257,7 @@ describe('lmnAnalytics', () => {
 
       expect(global.analytics.identify).to.have.been.calledWithMatch('12345', {
         email: 'test@example.com',
+        gaCookieId: 'not-set'
       });
     });
 


### PR DESCRIPTION
The original issue was this:
_page event properties can be in either the name or properties variable so currently the metadata would be lost._

While we were fixing the issue we came across issues manipulating the arguments object. After some debugging we decided it made more sense to use the parsing done further down each function for GTM and then explicitly send the request to Segment.

## Test Plan

- [ ] Test purchase journey including order complete