### PR TITLE
Ensure analytics is set up

### DIFF
--- a/src/lmn-gtm-analytics.js
+++ b/src/lmn-gtm-analytics.js
@@ -6,9 +6,9 @@ import uuid from 'uuid';
 function ensureSetup() {
   window.dataLayer = window.dataLayer || [];
   window.analytics = window.analytics || { 
-    track: function() {}, 
-    page: function() {}, 
-    identify: function() {} 
+    track: function () {}, 
+    page: function () {}, 
+    identify: function () {} 
   };
 }
 

--- a/src/lmn-gtm-analytics.js
+++ b/src/lmn-gtm-analytics.js
@@ -5,6 +5,11 @@ import uuid from 'uuid';
 
 function ensureSetup() {
   window.dataLayer = window.dataLayer || [];
+  window.analytics = window.analytics || { 
+    track: function() {}, 
+    page: function() {}, 
+    identify: function() {} 
+  };
 }
 
 function getClientUuid() {


### PR DESCRIPTION
If for whatever reason Segment isn't loading the analytics script, js breaks because `analytics is undefined` 🤦‍♀️ 

Rather than go through hundreds of deprecated js files and remove any references one by one, this _should_ gracefully allow `analytics` to continue running just a teensie bit longer